### PR TITLE
fix CI with pandas downgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [dependency-groups]
-dev = ["pytest>=8.3.4", "ruff>=0.9.7", "tqdm>=4.67.1", "pandas>=2.2.3"]
+dev = ["pytest>=8.3.4", "ruff>=0.9.7", "tqdm>=4.67.1", "pandas>=2.0.3"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["mishkal"]


### PR DESCRIPTION
CI pipeline fails when requiring higher pandas version, downgrading to retain compatibility with python 3.8