### PR TITLE
correct spelling (hat'ama)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Convert Hebrew text into IPA for TTS systems and learning.
 - The library depends on text with nikud,
 - the following hard to predict even from text with nikud
   - `Milel` - 
-      also named as `Atamha` / `Stress`. 
+      position of `Hat'ama` / `Stress`. 
       most of the time it's `Milra`
   - `Shva Na`. most of the time it's `Shva Nax`
 
@@ -62,7 +62,7 @@ See [examples](examples)
 
 ### Enhance vocabulary
 
-One of the best ways to improve this library is to ~add words with phonemes to the dictionary~ create tagged sentences with shva na and atmaha. you can listen to it with [phoneme-synthesis](https://itinerarium.github.io/phoneme-synthesis/)
+One of the best ways to improve this library is to ~add words with phonemes to the dictionary~ create tagged sentences with shva na and hat'ama. you can listen to it with [phoneme-synthesis](https://itinerarium.github.io/phoneme-synthesis/)
 
 ### Deduplication
 
@@ -72,10 +72,10 @@ One of the best ways to improve this library is to ~add words with phonemes to t
 
 - Chars from `\u05b0` to `\u05ea` (Letters and nikud)
 - `'"` (Gershaim),
-- `\u05ab` (Atmaha)
+- `\u05ab` (Hatma'a)
 - `\u05bd` (Shva Na)
 
-`\u05ab` and `\u05bd` are not standard - we invented them to mark `Atmaha` and `Shva Na` clearly.
+`\u05ab` and `\u05bd` are not standard - we invented them to mark `Hatma'a` and `Shva Na` clearly.
 
 
 See [Hebrew UTF-8](https://en.wikipedia.org/wiki/Unicode_and_HTML_for_the_Hebrew_alphabet#Compact_table)

--- a/mishkal/lexicon.py
+++ b/mishkal/lexicon.py
@@ -5,10 +5,10 @@ ASCII IPA transcription of Hebrew consonants and vowels.
 # https://en.wikipedia.org/wiki/Unicode_and_HTML_for_the_Hebrew_alphabet#Compact_table
 
 SHVA_NA_DIACRITIC = "\u05bd"
-ATAMAHA_DIACRITIC = "\u05ab"
+HATAMA_DIACRITIC = "\u05ab"
 STRESS = "\u02c8"  # visually looks like '
 
-MILHEL_PATTERNS = ['יים', 'וע', 'טו', "דיה"] # Used for stress prediction
+MILHEL_PATTERNS = ['יים', 'וע', 'טו', "דיה"]  # Used for stress prediction
 HE_PATTERN = r'[\u05b0-\u05ea\u05ab\u05bd\'"]+'
 HE_NIKUD_PATTERN = r"[\u05B0-\u05C7]"
 PUNCTUATION = r".,!? "
@@ -17,12 +17,12 @@ SPECIAL_PHONEMES = ['w']
 MODERN_SCHEMA_PHONEMES = ['χ', 'ʁ']
 
 GERESH_PHONEMES = {
-    "ג": "dʒ", 
-    "ז": 
-    "ʒ", 
-    "ת": "ta", 
-    "צ": 
-    "tʃ", 
+    "ג": "dʒ",
+    "ז":
+    "ʒ",
+    "ת": "ta",
+    "צ":
+    "tʃ",
     "ץ": "tʃ"
 }
 
@@ -76,9 +76,9 @@ NIKUD_PHONEMES = {
     "\u05b9": "o",  # Holam
     "\u05ba": "o",  # Holam haser for vav
     "\u05bb": "u",  # Qubuts
-    "\u05b3": 'o', # Hataf qamats
-    "\u05b8": "a", # Kamataz
-    ATAMAHA_DIACRITIC: "ˈ",  # Stress (Atmaha)
+    "\u05b3": 'o',  # Hataf qamats
+    "\u05b8": "a",  # Kamataz
+    HATAMA_DIACRITIC: "ˈ",  # Stress (Atmaha)
     SHVA_NA_DIACRITIC: "e",  # Shva na
 }
 
@@ -87,8 +87,8 @@ DEDUPLICATE = {
 }
 
 SET_PHONEMES = set(sorted({
-    *NIKUD_PHONEMES.values(), 
-    *LETTERS_PHONEMES.values(), 
+    *NIKUD_PHONEMES.values(),
+    *LETTERS_PHONEMES.values(),
     *GERESH_PHONEMES.values(),
     *SPECIAL_PHONEMES,
     *MODERN_SCHEMA_PHONEMES


### PR DESCRIPTION
In normal Latin transliteration the correct way to write הטעמה is hat'ama.